### PR TITLE
[FEAT]: Ajout des routes browse et read pour les catégories

### DIFF
--- a/server/src/modules/category/categoryActions.ts
+++ b/server/src/modules/category/categoryActions.ts
@@ -1,0 +1,32 @@
+const categories = [
+  {
+    id: 1,
+    name: "Comédie",
+  },
+  {
+    id: 2,
+    name: "Science-Fiction",
+  },
+];
+
+//Declare the actions
+import type { RequestHandler } from "express";
+
+const browse: RequestHandler = (req, res) => {
+  res.json(categories);
+};
+
+const read: RequestHandler = (req, res) => {
+  const parsedId = Number.parseInt(req.params.id);
+
+  const category = categories.find((c) => c.id === parsedId);
+
+  if (category != null) {
+    res.json(category);
+  } else {
+    res.sendStatus(404); // 404: Not Found
+  }
+};
+
+// Export it to import it somewhere else
+export default { browse, read };

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -17,11 +17,13 @@ router.get("/api/programs", programActions.browse);
 router.get("/api/programs/:id", programActions.read);
 
 import sayActions from "./modules/say/sayActions";
+router.get("/", sayActions.sayWelcome);
 
+import categoryActions from "./modules/category/categoryActions";
+router.get("/api/categories", categoryActions.browse);
+router.get("/api/categories/:id", categoryActions.read);
 /* ************************************************************************* */
 // Declaration of a "Welcome" route
-
-router.get("/", sayActions.sayWelcome);
 
 import type { RequestHandler } from "express";
 


### PR DESCRIPTION
- Ajout des routes `/api/categories` et `/api/categories/:id` pour gérer les catégories.
- Correction du paramètre `id` dans `categoryActions.read`.
- Testé localement avec succès sur les routes `/api/categories` et `/api/categories/:id`.
